### PR TITLE
Enhance skater controls and halfpipe environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 my-phaser-game/
+scaffolding/demo/phasers-revenge/public/rawart/background.png

--- a/scaffolding/demo/phasers-revenge/package.json
+++ b/scaffolding/demo/phasers-revenge/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "predev": "node scripts/generate-background.js",
     "dev": "vite",
+    "prebuild": "node scripts/generate-background.js",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/scaffolding/demo/phasers-revenge/scripts/generate-background.js
+++ b/scaffolding/demo/phasers-revenge/scripts/generate-background.js
@@ -1,0 +1,10 @@
+import { writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+const outDir = join(process.cwd(), 'public', 'rawart');
+mkdirSync(outDir, { recursive: true });
+
+// Placeholder 1x1 transparent PNG encoded in base64
+const pngBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAgEB/abeLpsAAAAASUVORK5CYII=';
+
+writeFileSync(join(outDir, 'background.png'), Buffer.from(pngBase64, 'base64'));

--- a/scaffolding/demo/phasers-revenge/src/entities/Skater.js
+++ b/scaffolding/demo/phasers-revenge/src/entities/Skater.js
@@ -2,27 +2,59 @@ import Phaser from 'phaser';
 
 export default class Skater extends Phaser.Physics.Arcade.Sprite {
     constructor(scene, x, y) {
-        super(scene, x, y, 'skater');
+        super(scene, x, y, 'skater', 0);
         scene.add.existing(this);
         scene.physics.add.existing(this);
+
         this.setCollideWorldBounds(true);
         this.speed = 200;
         this.jumpSpeed = 400;
+        this.kickBoost = 100;
+        this.direction = 1; // 1 = right, -1 = left
+        this.onPipe = false;
     }
 
     move(left, right) {
+        const grounded = this.body.blocked.down || this.onPipe;
+
         if (left) {
+            this.direction = -1;
+            this.setFlipX(true);
             this.setVelocityX(-this.speed);
+            if (grounded) {
+                this.anims.play('skate', true);
+            }
         } else if (right) {
+            this.direction = 1;
+            this.setFlipX(false);
             this.setVelocityX(this.speed);
+            if (grounded) {
+                this.anims.play('skate', true);
+            }
         } else {
             this.setVelocityX(0);
+            if (grounded) {
+                this.anims.play('idle', true);
+            }
         }
     }
 
     jump() {
-        if (this.body.blocked.down) {
+        if (this.body.blocked.down || this.onPipe) {
             this.setVelocityY(-this.jumpSpeed);
+            this.anims.play('jump', true);
+            this.onPipe = false;
         }
+    }
+
+    // Apply a speed boost in the current facing direction
+    kick() {
+        this.setVelocityX(this.direction * (this.speed + this.kickBoost));
+        this.anims.play('kick', true);
+    }
+
+    // Simple in-air trick animation
+    trick() {
+        this.anims.play('trick', true);
     }
 }

--- a/scaffolding/demo/phasers-revenge/src/scenes/Game.js
+++ b/scaffolding/demo/phasers-revenge/src/scenes/Game.js
@@ -12,27 +12,72 @@ export default class Game extends Phaser.Scene {
     }
 
     preload() {
-        const g = this.add.graphics();
-        g.fillStyle(0xffffff, 1);
-        g.fillRect(0, 0, 32, 16);
-        g.generateTexture('skater', 32, 16);
-        g.destroy();
+        // Load backdrop artwork (placeholder until real pixel art arrives)
+        this.load.image('background', '/rawart/background.png');
+
+        // Create a very simple placeholder sprite sheet for the skater
+        const size = 32;
+        const canvas = this.textures.createCanvas('skater-temp', size * 5, size);
+        const ctx = canvas.getContext();
+        ctx.fillStyle = '#ffffff'; ctx.fillRect(0, 0, size, size); // idle
+        ctx.fillStyle = '#bbbbbb'; ctx.fillRect(size, 0, size, size); // skate
+        ctx.fillStyle = '#ffff00'; ctx.fillRect(size * 2, 0, size, size); // jump
+        ctx.fillStyle = '#ff8800'; ctx.fillRect(size * 3, 0, size, size); // kick
+        ctx.fillStyle = '#ff00ff'; ctx.fillRect(size * 4, 0, size, size); // trick
+        canvas.refresh();
+        this.textures.addSpriteSheet('skater', canvas.canvas, { frameWidth: size, frameHeight: size });
+        this.textures.remove('skater-temp');
     }
 
     create() {
         const { width, height } = this.scale;
 
-        // Draw simple isometric halfpipe
-        const pipe = this.add.graphics({ x: width / 2, y: height / 2 + 100 });
-        pipe.fillStyle(0x808080, 1);
-        pipe.fillRect(-200, -50, 400, 100);
-        pipe.rotation = Phaser.Math.DegToRad(45);
+        // Add the pixel-art background
+        this.add.image(width / 2, height / 2, 'background');
 
+        // Halfpipe parameters based on provided pixel mapping
+        this.pipe = { centerX: 400, centerY: 200, radius: 300 };
+
+        // Precompute an exact y-map so the skater aligns with pixel art
+        this.yMap = Array(width + 1).fill(null);
+        const { centerX, centerY, radius } = this.pipe;
+        for (let x = 0; x <= width; x++) {
+            const dx = x - centerX;
+            if (Math.abs(dx) <= radius) {
+                this.yMap[x] = Math.round(centerY + Math.sqrt(radius * radius - dx * dx));
+            }
+        }
+
+        this.physics.world.gravity.y = 800;
         this.physics.world.setBounds(0, 0, width, height);
 
-        this.skater = new Skater(this, width / 2, height / 2 - 50);
+        const startY = this.getPipeY(centerX) - 20;
+        this.skater = new Skater(this, centerX, startY);
         this.controls = new Controls(this);
         this.hud = new HUD(this);
+
+        // Define animations
+        this.anims.create({ key: 'idle', frames: [{ key: 'skater', frame: 0 }] });
+        this.anims.create({ key: 'skate', frames: this.anims.generateFrameNumbers('skater', { frames: [0, 1] }), frameRate: 8, repeat: -1 });
+        this.anims.create({ key: 'jump', frames: [{ key: 'skater', frame: 2 }] });
+        this.anims.create({ key: 'kick', frames: [{ key: 'skater', frame: 3 }] });
+        this.anims.create({ key: 'trick', frames: [{ key: 'skater', frame: 4 }] });
+
+        this.skater.play('idle');
+    }
+
+    getPipeY(x) {
+        const xInt = Math.round(x);
+        return this.yMap[xInt] ?? null;
+    }
+
+    getPipeSlope(x) {
+        const { centerX, radius } = this.pipe;
+        const dx = x - centerX;
+        if (Math.abs(dx) >= radius) {
+            return 0;
+        }
+        return -(dx) / Math.sqrt(radius * radius - dx * dx);
     }
 
     update() {
@@ -42,7 +87,27 @@ export default class Game extends Phaser.Scene {
             this.skater.jump();
         }
 
-        if (!this.skater.body.blocked.down) {
+        if (this.controls.kick) {
+            if (this.skater.body.blocked.down || this.skater.onPipe) {
+                this.skater.kick();
+            } else {
+                this.skater.trick();
+            }
+        }
+
+        // Halfpipe collision and response
+        const pipeY = this.getPipeY(this.skater.x);
+        if (this.skater.y >= pipeY && this.skater.body.velocity.y >= 0) {
+            const slope = this.getPipeSlope(this.skater.x);
+            this.skater.onPipe = true;
+            this.skater.y = pipeY;
+            // Align vertical velocity with slope to preserve momentum
+            this.skater.body.velocity.y = this.skater.body.velocity.x * slope;
+        } else {
+            this.skater.onPipe = false;
+        }
+
+        if (!this.skater.onPipe) {
             const trick = checkTrick(this.controls);
             if (trick && trick !== this.currentTrick) {
                 this.currentTrick = trick;

--- a/scaffolding/demo/phasers-revenge/src/scenes/Menu.js
+++ b/scaffolding/demo/phasers-revenge/src/scenes/Menu.js
@@ -13,7 +13,7 @@ export default class Menu extends Phaser.Scene {
             color: '#ffffff'
         }).setOrigin(0.5);
 
-        const start = this.add.text(width / 2, height / 2, 'Start Game', {
+        const start = this.add.text(width / 2, height / 2, 'Press Space, A or S to Start', {
             fontSize: '24px',
             color: '#00ff00'
         }).setOrigin(0.5).setInteractive({ useHandCursor: true });
@@ -22,13 +22,14 @@ export default class Menu extends Phaser.Scene {
 
         start.on('pointerdown', launch);
 
-        this.input.keyboard.once('keydown-SPACE', launch);
+        ['SPACE', 'A', 'S'].forEach(key => {
+            this.input.keyboard.once(`keydown-${key}`, launch);
+        });
 
         const legend = [
             'Arrow Keys / D-Pad: Move',
-            'Space or A: Jump',
-            'CTRL / LB: Trick Mod',
-            'ALT / RB: Trick Mod'
+            'S: Jump',
+            'A: Kick'
         ];
 
         this.add.text(width / 2, height / 2 + 120, legend.join('\n'), {

--- a/scaffolding/demo/phasers-revenge/src/utils/controls.js
+++ b/scaffolding/demo/phasers-revenge/src/utils/controls.js
@@ -7,9 +7,10 @@ export default class Controls {
             down: Phaser.Input.Keyboard.KeyCodes.DOWN,
             left: Phaser.Input.Keyboard.KeyCodes.LEFT,
             right: Phaser.Input.Keyboard.KeyCodes.RIGHT,
-            jump: Phaser.Input.Keyboard.KeyCodes.SPACE,
-            ctrl: Phaser.Input.Keyboard.KeyCodes.CTRL,
-            alt: Phaser.Input.Keyboard.KeyCodes.ALT
+            // Remap jump to the "S" key
+            jump: Phaser.Input.Keyboard.KeyCodes.S,
+            // New kick / speed boost action on the "A" key
+            kick: Phaser.Input.Keyboard.KeyCodes.A
         });
 
         if (scene.input.gamepad) {
@@ -39,11 +40,8 @@ export default class Controls {
         return Phaser.Input.Keyboard.JustDown(this.keys.jump) || (this.pad && this.pad.A);
     }
 
-    get ctrl() {
-        return this.keys.ctrl.isDown || (this.pad && this.pad.LB);
-    }
-
-    get alt() {
-        return this.keys.alt.isDown || (this.pad && this.pad.RB);
+    // Kick (speed boost) triggered by the "A" key or gamepad B button
+    get kick() {
+        return Phaser.Input.Keyboard.JustDown(this.keys.kick) || (this.pad && this.pad.B);
     }
 }

--- a/scaffolding/demo/phasers-revenge/src/utils/tricks.js
+++ b/scaffolding/demo/phasers-revenge/src/utils/tricks.js
@@ -1,20 +1,20 @@
+// Trick combinations now rely on the kick button instead of Ctrl / Alt
 export const TRICKS = [
-    { keys: ['ctrl', 'up'], name: 'Kickflip' },
-    { keys: ['alt', 'down'], name: 'Heelflip' },
-    { keys: ['ctrl', 'left', 'down'], name: '360 Spin' },
-    { keys: ['alt', 'right', 'up'], name: 'Method Air' },
-    { keys: ['ctrl', 'right'], name: 'Indy Grab' },
-    { keys: ['alt', 'left'], name: 'Nosegrab' },
-    { keys: ['ctrl', 'up', 'left'], name: 'Stalefish' },
-    { keys: ['alt', 'up', 'right'], name: 'Tailgrab' },
-    { keys: ['ctrl', 'down', 'right'], name: 'Japan Air' },
-    { keys: ['alt', 'down', 'left'], name: 'Melon' }
+    { keys: ['kick', 'up'], name: 'Kickflip' },
+    { keys: ['kick', 'down'], name: 'Heelflip' },
+    { keys: ['kick', 'left', 'down'], name: '360 Spin' },
+    { keys: ['kick', 'right', 'up'], name: 'Method Air' },
+    { keys: ['kick', 'right'], name: 'Indy Grab' },
+    { keys: ['kick', 'left'], name: 'Nosegrab' },
+    { keys: ['kick', 'up', 'left'], name: 'Stalefish' },
+    { keys: ['kick', 'up', 'right'], name: 'Tailgrab' },
+    { keys: ['kick', 'down', 'right'], name: 'Japan Air' },
+    { keys: ['kick', 'down', 'left'], name: 'Melon' }
 ];
 
 export function checkTrick(controls) {
     const pressed = [];
-    if (controls.ctrl) pressed.push('ctrl');
-    if (controls.alt) pressed.push('alt');
+    if (controls.kick) pressed.push('kick');
     if (controls.up) pressed.push('up');
     if (controls.down) pressed.push('down');
     if (controls.left) pressed.push('left');

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,9 @@
 {
-  "installCommand": "cd scaffolding/demo/phasers-revenge && npm install",
-  "buildCommand": "cd scaffolding/demo/phasers-revenge && npm run build",
-  "outputDirectory": "scaffolding/demo/phasers-revenge/dist"
+  "builds": [
+    {
+      "src": "scaffolding/demo/phasers-revenge/package.json",
+      "use": "@vercel/static-build",
+      "config": { "distDir": "dist" }
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Preload and render a placeholder pixel-art halfpipe background
- Compute an exact halfpipe y-map so the skater follows the curved surface
- Configure Vercel to build the halfpipe demo at deploy time instead of committing prebuilt assets
- Generate the halfpipe background during build rather than storing a blank image in the repo
- Fix Vercel config to point the static build at the generated `dist` folder

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d93b1f1988329b0bb5c35c912eaca